### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ chatgpt-stream    /docker-entrypoint.sh ngin ...   Up      0.0.0.0:3000->80/tcp,
 # Pull build dependencies
 go mod tidy
 # Compile the project
+# If you want to build this GO project in Conda, please run *conda install -c anaconda gcc_linux-64* in your Conda env before *go build*
+# conda install -c anaconda gcc_linux-64
 go build
 
 # Run the service


### PR DESCRIPTION
solve an error that build this project in Conda env
When I trying to build ws in my Conda env, I have got an error 
```bash
(go) ubuntu@VM-0-10-ubuntu:~/chatgpt-service$ go build
# runtime/cgo
cgo: C compiler "x86_64-conda-linux-gnu-cc" not found: exec: "x86_64-conda-linux-gnu-cc": executable file not found in $PATH
```
The reason of this problem is Go can not find any gcc in this Conda env, so we need to run 
```bash
conda install -c anaconda gcc_linux-64
```
and then
```bash
go build
```